### PR TITLE
Parent pom net.wasdev.wlp.maven.parent to ver 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>net.wasdev.wlp.maven.parent</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.1.1</version>
 	</parent>
 
 	<groupId>liberty.maven</groupId>


### PR DESCRIPTION
Before this change it was throwing errors
```
$ mvn install
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for liberty.maven:jpaApp:1: Could not find artifact net.wasdev.wlp.maven.parent:liberty-maven-app-parent:pom:2.1-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 12, column 11
```