### PR TITLE
Add localConnector-1.0 feature to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                                 <feature>servlet-3.1</feature>
                                 <feature>jdbc-4.1</feature>
                                 <feature>jpa-2.0</feature>
+                                <feature>localConnector-1.0</feature>
                             </features>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Though I believe newer versions of the liberty plugin will merge the feature install set, this version will only install the versions in  the pom.xml.

So to make it easier to work with WDT, this adds         `<feature>localConnector-1.0</feature>`
 to the pom.xml as well.